### PR TITLE
Add sans-serif font for dark theme

### DIFF
--- a/resources/sass/app-dark.scss
+++ b/resources/sass/app-dark.scss
@@ -1,4 +1,4 @@
-$font-family-base: Nunito;
+$font-family-base: Nunito, sans-serif;
 $font-size-base: 0.95rem;
 $badge-font-size: 0.95rem;
 


### PR DESCRIPTION
Hi! Light theme has sans-serif font and dark theme has not.