### PR TITLE
Support displaying child workflows

### DIFF
--- a/app/Dto/ChartDataPoint.php
+++ b/app/Dto/ChartDataPoint.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Waterline\Dto;
+
+use JsonSerializable;
+
+class ChartDataPoint implements JsonSerializable
+{
+    public function __construct(
+        private string $x,
+        private float | int $yMin,
+        private float | int $yMax,
+    ) {}
+
+    public function jsonSerialize(): mixed
+    {
+        return [
+            'x' => $this->x,
+            'y' => [$this->yMin, $this->yMax],
+        ];
+    }
+}

--- a/app/Dto/ChartDataPoint.php
+++ b/app/Dto/ChartDataPoint.php
@@ -11,6 +11,7 @@ class ChartDataPoint implements JsonSerializable
         private string $x,
         private float | int $yMin,
         private float | int $yMax,
+        private string $type,
     ) {}
 
     public function jsonSerialize(): mixed
@@ -18,6 +19,7 @@ class ChartDataPoint implements JsonSerializable
         return [
             'x' => $this->x,
             'y' => [$this->yMin, $this->yMax],
+            'type' => $this->type,
         ];
     }
 }

--- a/app/Http/Resources/StoredWorkflowExceptionResource.php
+++ b/app/Http/Resources/StoredWorkflowExceptionResource.php
@@ -47,9 +47,4 @@ class StoredWorkflowExceptionResource extends JsonResource
             "created_at" => $this->created_at,
         ];
     }
-
-    private function mapExceptions()
-    {
-
-    }
 }

--- a/app/Http/Resources/StoredWorkflowExceptionResource.php
+++ b/app/Http/Resources/StoredWorkflowExceptionResource.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace Waterline\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use SplFileObject;
+use Waterline\Transformer\WorkflowToChartDataTransformer;
+use Workflow\Models\StoredWorkflow;
+use Workflow\Models\StoredWorkflowException;
+use Workflow\Serializers\Y;
+
+/**
+ * @mixin StoredWorkflowException
+ */
+class StoredWorkflowExceptionResource extends JsonResource
+{
+    public static $wrap = null;
+
+    public function toArray(Request $request)
+    {
+        $code = null;
+        $exception = $this->exception;
+
+        $unserialized = Y::unserialize($exception);
+        if (is_array($unserialized)
+            && array_key_exists('class', $unserialized)
+            && is_subclass_of($unserialized['class'], \Throwable::class)
+            && file_exists($unserialized['file'])
+        ) {
+            $file = new SplFileObject($unserialized['file']);
+            $file->seek($unserialized['line'] - 4);
+            for ($line = 0; $line < 7; ++$line) {
+                $exception->code .= $file->current();
+                $file->next();
+                if ($file->eof()) break;
+            }
+            $code = rtrim($exception->code);
+            $exception = serialize($unserialized);
+        }
+
+        return [
+            "code" => $code,
+            "exception" => $exception,
+            "class" => $this->class,
+            "created_at" => $this->created_at,
+        ];
+    }
+
+    private function mapExceptions()
+    {
+
+    }
+}

--- a/app/Http/Resources/StoredWorkflowLogResource.php
+++ b/app/Http/Resources/StoredWorkflowLogResource.php
@@ -28,9 +28,4 @@ class StoredWorkflowLogResource extends JsonResource
             "created_at" => $this->created_at,
         ];
     }
-
-    private function mapExceptions()
-    {
-
-    }
 }

--- a/app/Http/Resources/StoredWorkflowLogResource.php
+++ b/app/Http/Resources/StoredWorkflowLogResource.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Waterline\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Waterline\Transformer\WorkflowToChartDataTransformer;
+use Workflow\Models\StoredWorkflow;
+use Workflow\Models\StoredWorkflowLog;
+use Workflow\Serializers\Y;
+
+/**
+ * @mixin StoredWorkflowLog
+ */
+class StoredWorkflowLogResource extends JsonResource
+{
+    public static $wrap = null;
+
+    public function toArray(Request $request)
+    {
+        return [
+            "id" => $this->id,
+            "index" => $this->index,
+            "now" => $this->now,
+            "class" => $this->class,
+            "result" => serialize(Y::unserialize($this->result)),
+            "created_at" => $this->created_at,
+        ];
+    }
+
+    private function mapExceptions()
+    {
+
+    }
+}

--- a/app/Http/Resources/StoredWorkflowResource.php
+++ b/app/Http/Resources/StoredWorkflowResource.php
@@ -31,9 +31,4 @@ class StoredWorkflowResource extends JsonResource
             "chartData" => app(WorkflowToChartDataTransformer::class)->transform($this->resource),
         ];
     }
-
-    private function mapExceptions()
-    {
-
-    }
 }

--- a/app/Http/Resources/StoredWorkflowResource.php
+++ b/app/Http/Resources/StoredWorkflowResource.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Waterline\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Waterline\Transformer\WorkflowToChartDataTransformer;
+use Workflow\Models\StoredWorkflow;
+use Workflow\Serializers\Y;
+
+/**
+ * @mixin StoredWorkflow
+ */
+class StoredWorkflowResource extends JsonResource
+{
+    public static $wrap = null;
+
+    public function toArray(Request $request)
+    {
+        return [
+            "id" => $this->id,
+            "class" => $this->class,
+            "arguments" => serialize(Y::unserialize($this->arguments)),
+            "output" => $this->output === null ? serialize(null) : serialize(Y::unserialize($this->output)),
+            "status" => $this->status,
+            "created_at" => $this->created_at,
+            "updated_at" => $this->updated_at,
+            "logs" => StoredWorkflowLogResource::collection($this->logs),
+            "exceptions" => StoredWorkflowExceptionResource::collection($this->exceptions),
+            "chartData" => app(WorkflowToChartDataTransformer::class)->transform($this->resource),
+        ];
+    }
+
+    private function mapExceptions()
+    {
+
+    }
+}

--- a/app/Transformer/WorkflowToChartDataTransformer.php
+++ b/app/Transformer/WorkflowToChartDataTransformer.php
@@ -37,7 +37,8 @@ class WorkflowToChartDataTransformer
             app(ChartDataPoint::class, [
                 'x' => $storedWorkflow->class,
                 'yMin' => (float) $storedWorkflow->created_at->isoFormat('XSSS'),
-                'yMax' => (float) $storedWorkflow->updated_at->isoFormat('XSSS',),
+                'yMax' => (float) $storedWorkflow->updated_at->isoFormat('XSSS'),
+                'type' => 'Workflow'
             ])
         ];
 
@@ -63,6 +64,7 @@ class WorkflowToChartDataTransformer
             'x' => $storedWorkflowLog->class,
             'yMin' => (float) $prevLogCreated->isoFormat('XSSS'),
             'yMax' => (float) $storedWorkflowLog->created_at->isoFormat('XSSS'),
+            'type' => 'Activity',
         ]);
     }
 }

--- a/app/Transformer/WorkflowToChartDataTransformer.php
+++ b/app/Transformer/WorkflowToChartDataTransformer.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace Waterline\Transformer;
+
+use Carbon\CarbonInterface;
+use DateTimeInterface;
+use Illuminate\Support\Arr;
+use Waterline\Dto\ChartDataPoint;
+use Workflow\Models\StoredWorkflow;
+use Workflow\Models\StoredWorkflowLog;
+use Workflow\Workflow;
+
+class WorkflowToChartDataTransformer
+{
+    /**
+     * @return ChartDataPoint[]
+     */
+    public function transform(StoredWorkflow $storedWorkflow) : array {
+        $data = $this->transformWorkflow($storedWorkflow);
+
+        foreach ($storedWorkflow->children as $childWorkflow) {
+            $data = array_merge(
+                $data,
+                $this->transform($childWorkflow),
+            );
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return ChartDataPoint
+     */
+    private function transformWorkflow(StoredWorkflow $storedWorkflow) : array {
+        $data = [
+            app(ChartDataPoint::class, [
+                'x' => $storedWorkflow->class,
+                'yMin' => (float) $storedWorkflow->created_at->isoFormat('XSSS'),
+                'yMax' => (float) $storedWorkflow->updated_at->isoFormat('XSSS',),
+            ])
+        ];
+
+        $prevLogCreated = $storedWorkflow->created_at;
+        foreach ($storedWorkflow->logs as $log) {
+            if (is_subclass_of($log->class, Workflow::class)) {
+                continue;
+            }
+
+            $data[] = $this->transformLog($log, $prevLogCreated);
+            $prevLogCreated = $log->created_at;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return ChartDataPoint
+     */
+    private function transformLog(StoredWorkflowLog $storedWorkflowLog, CarbonInterface $prevLogCreated) : ChartDataPoint {
+
+        return app(ChartDataPoint::class, [
+            'x' => $storedWorkflowLog->class,
+            'yMin' => (float) $prevLogCreated->isoFormat('XSSS'),
+            'yMax' => (float) $storedWorkflowLog->created_at->isoFormat('XSSS'),
+        ]);
+    }
+}

--- a/app/Transformer/WorkflowToChartDataTransformer.php
+++ b/app/Transformer/WorkflowToChartDataTransformer.php
@@ -30,7 +30,7 @@ class WorkflowToChartDataTransformer
     }
 
     /**
-     * @return ChartDataPoint
+     * @return ChartDataPoint[]
      */
     private function transformWorkflow(StoredWorkflow $storedWorkflow) : array {
         $data = [

--- a/public/app.js
+++ b/public/app.js
@@ -2332,12 +2332,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
       this.ready = false;
       this.$http.get(Waterline.basePath + '/api/flows/' + id).then(function (response) {
         _this2.flow = response.data;
-        _this2.series[0].data = _this2.flow.logs.map(function (activity, index, activities) {
-          return {
-            x: activity["class"],
-            y: [index === 0 ? moment_timezone__WEBPACK_IMPORTED_MODULE_1___default()(_this2.flow.created_at).valueOf() : moment_timezone__WEBPACK_IMPORTED_MODULE_1___default()(activities[index - 1].created_at).valueOf(), moment_timezone__WEBPACK_IMPORTED_MODULE_1___default()(activity.created_at).valueOf()]
-          };
-        });
+        _this2.series[0].data = response.data.chartData;
         _this2.series[1].data = _this2.flow.exceptions.map(function (exception) {
           _this2.$nextTick(function () {
             _this2.$nextTick(function () {

--- a/public/app.js
+++ b/public/app.js
@@ -2280,7 +2280,7 @@ function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" =
               w = _ref.w;
             if (seriesIndex === 0) {
               var data = w.globals.initialSeries[seriesIndex].data[dataPointIndex];
-              return '<div style="padding: 1em">' + '<b>Activity</b>: ' + data.x.split('_')[0] + '<br />' + '<b>Time</b>: ' + (data.y[1] - data.y[0]) + 'ms </div>';
+              return '<div style="padding: 1em">' + '<b>' + data.type + '</b>: ' + data.x.split('_')[0] + '<br />' + '<b>Time</b>: ' + (data.y[1] - data.y[0]) + 'ms </div>';
             }
             if (seriesIndex === 1) {
               var exception = phpunserialize__WEBPACK_IMPORTED_MODULE_0___default()(_this.flow.exceptions[dataPointIndex].exception);

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/app.js": "/app.js?id=ad4fe9437176e22cd21076e124a481f3",
+    "/app.js": "/app.js?id=de5c3d9517f2ee9ade430df2d873d730",
     "/app-dark.css": "/app-dark.css?id=3e8dddb1d146175eb19d916f9cd87bfa",
     "/app.css": "/app.css?id=12fca36d651455c3d460d9c4abf772c5",
     "/img/favicon.png": "/img/favicon.png?id=7c006241b093796d6abfa3049df93a59",

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/app.js": "/app.js?id=de5c3d9517f2ee9ade430df2d873d730",
+    "/app.js": "/app.js?id=d8462d5df178a947e8a71869b5ea1018",
     "/app-dark.css": "/app-dark.css?id=3e8dddb1d146175eb19d916f9cd87bfa",
     "/app.css": "/app.css?id=12fca36d651455c3d460d9c4abf772c5",
     "/img/favicon.png": "/img/favicon.png?id=7c006241b093796d6abfa3049df93a59",

--- a/resources/js/screens/flows/flow.vue
+++ b/resources/js/screens/flows/flow.vue
@@ -233,7 +233,7 @@ export default {
                             let data = w.globals.initialSeries[seriesIndex].data[dataPointIndex]
 
                             return '<div style="padding: 1em">' +
-                                '<b>Activity</b>: ' + data.x.split('_')[0] + '<br />' +
+                                '<b>'+data.type+'</b>: ' + data.x.split('_')[0] + '<br />' +
                                 '<b>Time</b>: ' + (data.y[1] - data.y[0]) + 'ms </div>'
                         }
                         if (seriesIndex === 1) {

--- a/resources/js/screens/flows/flow.vue
+++ b/resources/js/screens/flows/flow.vue
@@ -298,16 +298,7 @@ export default {
             this.$http.get(Waterline.basePath + '/api/flows/' + id)
                 .then(response => {
                     this.flow = response.data;
-                    this.series[0].data = this.flow.logs.map((activity, index, activities) => {
-                        return {
-                            x: activity.class,
-                            y: [
-                                index === 0 ? moment(this.flow.created_at).valueOf() : moment(activities[index - 1].created_at).valueOf(),
-                                moment(activity.created_at).valueOf(),
-                            ],
-                        }
-                    })
-
+                    this.series[0].data = response.data.chartData;
                     this.series[1].data = this.flow.exceptions.map((exception) => {
                         this.$nextTick(() => {
                             this.$nextTick(() => {
@@ -331,7 +322,7 @@ export default {
                             ],
                             fillColor: '#721c24',
                         }
-                    })
+                    });
 
                     this.ready = true;
                 });


### PR DESCRIPTION
This PR adds the possibility to recursively display child workflows and their activities in the UI.

![Bildschirmfoto 2023-11-08 um 11 22 56](https://github.com/laravel-workflow/waterline/assets/5753604/c3ce9220-6f04-4c3a-ae3c-5ba463e5b5e4)
![Bildschirmfoto 2023-11-08 um 11 23 08](https://github.com/laravel-workflow/waterline/assets/5753604/50455a3d-186c-41ca-b53c-476bba62d774)
![Bildschirmfoto 2023-11-08 um 11 23 17](https://github.com/laravel-workflow/waterline/assets/5753604/f549f8e8-1819-4030-a3e9-d67c1e60ec5f)
