### PR TITLE
Add stored workflow exception id to the resource

### DIFF
--- a/app/Http/Resources/StoredWorkflowExceptionResource.php
+++ b/app/Http/Resources/StoredWorkflowExceptionResource.php
@@ -38,6 +38,7 @@ class StoredWorkflowExceptionResource extends JsonResource
         }
 
         return [
+            "id" => $this->id,
             "code" => $code,
             "exception" => $exception,
             "class" => $this->class,

--- a/tests/Feature/DashboardWorkflowTest.php
+++ b/tests/Feature/DashboardWorkflowTest.php
@@ -61,7 +61,10 @@ class DashboardWorkflowTest extends TestCase
                         'exceptions',
                         1,
                         fn (AssertableJson $exception) => $exception
-                            ->whereType('id', 'integer')
+                            ->where(
+                                'id',
+                                fn ($value) => is_string($value) || is_int($value)
+                            )
                             ->whereType('code', 'string')
                             ->whereType('exception', 'string')
                             ->where('class', 'Activity2Class')

--- a/tests/Feature/DashboardWorkflowTest.php
+++ b/tests/Feature/DashboardWorkflowTest.php
@@ -61,7 +61,7 @@ class DashboardWorkflowTest extends TestCase
                         'exceptions',
                         1,
                         fn (AssertableJson $exception) => $exception
-                            ->whereType('id', 'string')
+                            ->whereType('id', 'integer')
                             ->whereType('code', 'string')
                             ->whereType('exception', 'string')
                             ->where('class', 'Activity2Class')

--- a/tests/Feature/DashboardWorkflowTest.php
+++ b/tests/Feature/DashboardWorkflowTest.php
@@ -61,7 +61,7 @@ class DashboardWorkflowTest extends TestCase
                         'exceptions',
                         1,
                         fn (AssertableJson $exception) => $exception
-                            ->whereType('id', 'integer')
+                            ->whereType('id', 'string')
                             ->whereType('code', 'string')
                             ->whereType('exception', 'string')
                             ->where('class', 'Activity2Class')

--- a/tests/Feature/DashboardWorkflowTest.php
+++ b/tests/Feature/DashboardWorkflowTest.php
@@ -61,6 +61,7 @@ class DashboardWorkflowTest extends TestCase
                         'exceptions',
                         1,
                         fn (AssertableJson $exception) => $exception
+                            ->whereType('id', 'integer')
                             ->whereType('code', 'string')
                             ->whereType('exception', 'string')
                             ->where('class', 'Activity2Class')


### PR DESCRIPTION
The id is used to expand / collapse exception accordions

Not returning the id resulted in html ids like 'collapseundefined', so all exceptions would expand or collapse at the same time

![image](https://github.com/user-attachments/assets/e93dd75b-b518-4eef-9494-75b781dda2d6)
