### PR TITLE
Prepare live dashboard for Copilot setup

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     permissions:
       contents: read
@@ -23,32 +23,40 @@ jobs:
 
       - name: Start devcontainer services
         run: |
-          docker compose -f .devcontainer/docker/docker-compose.yml up -d --build --wait --wait-timeout 180 mysql redis pgsql mssql
+          docker compose -f .devcontainer/docker/docker-compose.yml up -d --build --wait --wait-timeout 180 mysql redis pgsql mssql laravel
 
-      - name: Validate composer.json and smoke test feature suites
+      - name: Prepare dashboard and queue worker
         run: |
-          docker compose -f .devcontainer/docker/docker-compose.yml run --rm --build --no-deps --entrypoint bash laravel -lc '
+          curl --fail --retry 30 --retry-delay 2 --retry-connrefused http://127.0.0.1:18280 > /dev/null
+          docker compose -f .devcontainer/docker/docker-compose.yml exec -T laravel bash -lc '
+            cd /var/www/html &&
             git config --global --add safe.directory /var/www/html &&
             mkdir -p workbench/bootstrap/cache &&
             mkdir -p workbench/storage/framework/cache &&
             mkdir -p workbench/storage/framework/sessions &&
             mkdir -p workbench/storage/framework/views &&
             mkdir -p workbench/storage/logs &&
-            composer install --prefer-dist --no-progress --no-interaction &&
             chmod -R ug+rwX workbench/bootstrap/cache workbench/storage &&
-            composer validate --strict &&
-            echo "Running feature suite against MySQL" &&
-            vendor/bin/phpunit --testdox --configuration=phpunit-mysql.xml --testsuite Feature &&
-            echo "Running feature suite against PostgreSQL" &&
-            vendor/bin/phpunit --testdox --configuration=phpunit-pgsql.xml --testsuite Feature &&
-            echo "Running feature suite against SQL Server" &&
-            vendor/bin/phpunit --testdox --configuration=phpunit-mssql.xml --testsuite Feature
+            ./vendor/bin/testbench workbench:create-sqlite-db &&
+            ./vendor/bin/testbench migrate:fresh --database=sqlite &&
+            ./vendor/bin/testbench waterline:publish
           '
+          docker compose -f .devcontainer/docker/docker-compose.yml exec -d laravel bash -lc '
+            cd /var/www/html &&
+            ./vendor/bin/testbench queue:work --tries=1 --timeout=90
+          '
+          docker compose -f .devcontainer/docker/docker-compose.yml exec -T laravel bash -lc 'ps -ef | grep "[q]ueue:work"'
+          docker compose -f .devcontainer/docker/docker-compose.yml exec -T laravel bash -lc '
+            cd /var/www/html &&
+            ./vendor/bin/testbench workflow:create-test &&
+            ./vendor/bin/testbench workflow:create-test-parent &&
+            ./vendor/bin/testbench workflow:create-test-continue-as-new
+          '
+          sleep 5
+          curl --fail --retry 10 --retry-delay 2 --retry-connrefused http://127.0.0.1:18280/waterline > /dev/null
 
       - name: Show compose logs if checks fail
         if: failure()
-        run: docker compose -f .devcontainer/docker/docker-compose.yml logs --no-color
-
-      - name: Tear down devcontainer services
-        if: always()
-        run: docker compose -f .devcontainer/docker/docker-compose.yml down -v --remove-orphans
+        run: |
+          docker compose -f .devcontainer/docker/docker-compose.yml logs --no-color
+          docker compose -f .devcontainer/docker/docker-compose.yml exec -T laravel bash -lc 'ps -ef'

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -17,6 +17,9 @@ jobs:
     permissions:
       contents: read
 
+    env:
+      APP_PORT: 18280
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -28,7 +31,12 @@ jobs:
 
       - name: Prepare dashboard and queue worker
         run: |
-          docker compose -f .devcontainer/docker/docker-compose.yml run --rm --no-deps --entrypoint bash laravel -lc '
+          docker compose -f .devcontainer/docker/docker-compose.yml run --rm --no-deps \
+            -e APP_ENV=local \
+            -e APP_DEBUG=true \
+            -e APP_URL=http://127.0.0.1:${APP_PORT} \
+            -e ASSET_URL=http://127.0.0.1:${APP_PORT} \
+            --entrypoint bash laravel -lc '
             cd /var/www/html &&
             git config --global --add safe.directory /var/www/html &&
             mkdir -p workbench/bootstrap/cache &&
@@ -43,7 +51,12 @@ jobs:
             ./vendor/bin/testbench migrate:fresh --database=sqlite &&
             ./vendor/bin/testbench waterline:publish
           '
-          docker compose -f .devcontainer/docker/docker-compose.yml run -d --name waterline-copilot-app --service-ports --no-deps --entrypoint bash laravel -lc '
+          docker compose -f .devcontainer/docker/docker-compose.yml run -d --name waterline-copilot-app --service-ports --no-deps \
+            -e APP_ENV=local \
+            -e APP_DEBUG=true \
+            -e APP_URL=http://127.0.0.1:${APP_PORT} \
+            -e ASSET_URL=http://127.0.0.1:${APP_PORT} \
+            --entrypoint bash laravel -lc '
             cd /var/www/html &&
             git config --global --add safe.directory /var/www/html &&
             mkdir -p workbench/bootstrap/cache &&
@@ -54,7 +67,12 @@ jobs:
             chmod -R ug+rwX workbench/bootstrap/cache workbench/storage &&
             php -S 0.0.0.0:80 -t workbench/public workbench/server.php
           '
-          docker compose -f .devcontainer/docker/docker-compose.yml run -d --name waterline-copilot-worker --no-deps --entrypoint bash laravel -lc '
+          docker compose -f .devcontainer/docker/docker-compose.yml run -d --name waterline-copilot-worker --no-deps \
+            -e APP_ENV=local \
+            -e APP_DEBUG=true \
+            -e APP_URL=http://127.0.0.1:${APP_PORT} \
+            -e ASSET_URL=http://127.0.0.1:${APP_PORT} \
+            --entrypoint bash laravel -lc '
             cd /var/www/html &&
             git config --global --add safe.directory /var/www/html &&
             mkdir -p workbench/bootstrap/cache &&
@@ -66,25 +84,32 @@ jobs:
             ./vendor/bin/testbench queue:work --tries=1 --timeout=90
           '
           for attempt in $(seq 1 30); do
-            if curl --fail --silent http://127.0.0.1:18280 > /dev/null; then
+            if curl --fail --silent --show-error http://127.0.0.1:${APP_PORT}/waterline > /dev/null; then
               break
             fi
             sleep 2
           done
-          curl --fail --silent http://127.0.0.1:18280 > /dev/null
+          curl --fail --silent --show-error http://127.0.0.1:${APP_PORT}/waterline > /dev/null
           docker exec waterline-copilot-worker bash -lc 'ps -ef | grep "[q]ueue:work"'
-          docker compose -f .devcontainer/docker/docker-compose.yml run --rm --no-deps --entrypoint bash laravel -lc '
+          docker compose -f .devcontainer/docker/docker-compose.yml run --rm --no-deps \
+            -e APP_ENV=local \
+            -e APP_DEBUG=true \
+            -e APP_URL=http://127.0.0.1:${APP_PORT} \
+            -e ASSET_URL=http://127.0.0.1:${APP_PORT} \
+            --entrypoint bash laravel -lc '
             cd /var/www/html &&
             ./vendor/bin/testbench workflow:create-test &&
             ./vendor/bin/testbench workflow:create-test-parent &&
             ./vendor/bin/testbench workflow:create-test-continue-as-new
           '
           sleep 5
-          curl --fail --silent http://127.0.0.1:18280/waterline > /dev/null
+          curl --fail --silent --show-error http://127.0.0.1:${APP_PORT}/waterline/api/stats > /dev/null
 
       - name: Show compose logs if checks fail
         if: failure()
         run: |
+          curl --include --silent --show-error http://127.0.0.1:${APP_PORT}/waterline || true
+          curl --include --silent --show-error http://127.0.0.1:${APP_PORT}/waterline/api/stats || true
           docker compose -f .devcontainer/docker/docker-compose.yml logs --no-color
           docker logs waterline-copilot-app || true
           docker logs waterline-copilot-worker || true

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -23,12 +23,12 @@ jobs:
 
       - name: Start devcontainer services
         run: |
-          docker compose -f .devcontainer/docker/docker-compose.yml up -d --build --wait --wait-timeout 180 mysql redis pgsql mssql laravel
+          docker compose -f .devcontainer/docker/docker-compose.yml up -d --build --wait --wait-timeout 180 mysql redis pgsql mssql
+          docker compose -f .devcontainer/docker/docker-compose.yml build laravel
 
       - name: Prepare dashboard and queue worker
         run: |
-          curl --fail --retry 30 --retry-delay 2 --retry-connrefused http://127.0.0.1:18280 > /dev/null
-          docker compose -f .devcontainer/docker/docker-compose.yml exec -T laravel bash -lc '
+          docker compose -f .devcontainer/docker/docker-compose.yml run --rm --no-deps --entrypoint bash laravel -lc '
             cd /var/www/html &&
             git config --global --add safe.directory /var/www/html &&
             mkdir -p workbench/bootstrap/cache &&
@@ -37,26 +37,54 @@ jobs:
             mkdir -p workbench/storage/framework/views &&
             mkdir -p workbench/storage/logs &&
             chmod -R ug+rwX workbench/bootstrap/cache workbench/storage &&
+            composer install --prefer-dist --no-progress --no-interaction &&
+            composer run build &&
             ./vendor/bin/testbench workbench:create-sqlite-db &&
             ./vendor/bin/testbench migrate:fresh --database=sqlite &&
             ./vendor/bin/testbench waterline:publish
           '
-          docker compose -f .devcontainer/docker/docker-compose.yml exec -d laravel bash -lc '
+          docker compose -f .devcontainer/docker/docker-compose.yml run -d --name waterline-copilot-app --service-ports --no-deps --entrypoint bash laravel -lc '
             cd /var/www/html &&
+            git config --global --add safe.directory /var/www/html &&
+            mkdir -p workbench/bootstrap/cache &&
+            mkdir -p workbench/storage/framework/cache &&
+            mkdir -p workbench/storage/framework/sessions &&
+            mkdir -p workbench/storage/framework/views &&
+            mkdir -p workbench/storage/logs &&
+            chmod -R ug+rwX workbench/bootstrap/cache workbench/storage &&
+            SERVER_HOST=0.0.0.0 SERVER_PORT=80 php vendor/bin/testbench serve --ansi
+          '
+          docker compose -f .devcontainer/docker/docker-compose.yml run -d --name waterline-copilot-worker --no-deps --entrypoint bash laravel -lc '
+            cd /var/www/html &&
+            git config --global --add safe.directory /var/www/html &&
+            mkdir -p workbench/bootstrap/cache &&
+            mkdir -p workbench/storage/framework/cache &&
+            mkdir -p workbench/storage/framework/sessions &&
+            mkdir -p workbench/storage/framework/views &&
+            mkdir -p workbench/storage/logs &&
+            chmod -R ug+rwX workbench/bootstrap/cache workbench/storage &&
             ./vendor/bin/testbench queue:work --tries=1 --timeout=90
           '
-          docker compose -f .devcontainer/docker/docker-compose.yml exec -T laravel bash -lc 'ps -ef | grep "[q]ueue:work"'
-          docker compose -f .devcontainer/docker/docker-compose.yml exec -T laravel bash -lc '
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent http://127.0.0.1:18280 > /dev/null; then
+              break
+            fi
+            sleep 2
+          done
+          curl --fail --silent http://127.0.0.1:18280 > /dev/null
+          docker exec waterline-copilot-worker bash -lc 'ps -ef | grep "[q]ueue:work"'
+          docker compose -f .devcontainer/docker/docker-compose.yml run --rm --no-deps --entrypoint bash laravel -lc '
             cd /var/www/html &&
             ./vendor/bin/testbench workflow:create-test &&
             ./vendor/bin/testbench workflow:create-test-parent &&
             ./vendor/bin/testbench workflow:create-test-continue-as-new
           '
           sleep 5
-          curl --fail --retry 10 --retry-delay 2 --retry-connrefused http://127.0.0.1:18280/waterline > /dev/null
+          curl --fail --silent http://127.0.0.1:18280/waterline > /dev/null
 
       - name: Show compose logs if checks fail
         if: failure()
         run: |
           docker compose -f .devcontainer/docker/docker-compose.yml logs --no-color
-          docker compose -f .devcontainer/docker/docker-compose.yml exec -T laravel bash -lc 'ps -ef'
+          docker logs waterline-copilot-app || true
+          docker logs waterline-copilot-worker || true

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -98,9 +98,7 @@ jobs:
             -e ASSET_URL=http://127.0.0.1:${APP_PORT} \
             --entrypoint bash laravel -lc '
             cd /var/www/html &&
-            ./vendor/bin/testbench workflow:create-test &&
-            ./vendor/bin/testbench workflow:create-test-parent &&
-            ./vendor/bin/testbench workflow:create-test-continue-as-new
+            ./vendor/bin/testbench workflow:seed-dashboard-fixtures
           '
           sleep 5
           curl --fail --silent --show-error http://127.0.0.1:${APP_PORT}/waterline/api/stats > /dev/null

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -52,7 +52,7 @@ jobs:
             mkdir -p workbench/storage/framework/views &&
             mkdir -p workbench/storage/logs &&
             chmod -R ug+rwX workbench/bootstrap/cache workbench/storage &&
-            SERVER_HOST=0.0.0.0 SERVER_PORT=80 php vendor/bin/testbench serve --ansi
+            php -S 0.0.0.0:80 -t workbench/public workbench/server.php
           '
           docker compose -f .devcontainer/docker/docker-compose.yml run -d --name waterline-copilot-worker --no-deps --entrypoint bash laravel -lc '
             cd /var/www/html &&

--- a/workbench/app/Console/SeedDashboardFixtures.php
+++ b/workbench/app/Console/SeedDashboardFixtures.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Workbench\App\Console;
+
+use Exception;
+use Illuminate\Console\Command;
+use Illuminate\Support\CarbonImmutable;
+use Workflow\Models\StoredWorkflow;
+use Workflow\Serializers\Serializer;
+
+class SeedDashboardFixtures extends Command
+{
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'workflow:seed-dashboard-fixtures';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Seed dashboard fixtures for local UI and Copilot setup';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        if (StoredWorkflow::query()->exists()) {
+            $this->info('Dashboard fixtures already exist.');
+
+            return Command::SUCCESS;
+        }
+
+        $now = CarbonImmutable::now();
+
+        $running = StoredWorkflow::create([
+            'class' => \Workbench\App\Workflows\TestWorkflow::class,
+            'arguments' => Serializer::serialize([]),
+            'output' => null,
+            'status' => 'waiting',
+            'created_at' => $now->subMinutes(4),
+            'updated_at' => $now->subSeconds(20),
+        ]);
+
+        $running->logs()->create([
+            'index' => 0,
+            'now' => $now->subSeconds(30),
+            'class' => 'Workbench\App\Activities\RenderDashboard',
+            'result' => Serializer::serialize(['status' => 'queued']),
+            'created_at' => $now->subSeconds(30),
+        ]);
+
+        $running->signals()->create([
+            'method' => 'approve',
+            'arguments' => Serializer::serialize(['source' => 'copilot-setup']),
+            'created_at' => $now->subSeconds(15),
+        ]);
+
+        $completed = StoredWorkflow::create([
+            'class' => \Workbench\App\Workflows\TestParentWorkflow::class,
+            'arguments' => Serializer::serialize(['batch' => 'daily']),
+            'output' => Serializer::serialize(['ok' => true]),
+            'status' => 'completed',
+            'created_at' => $now->subHours(2),
+            'updated_at' => $now->subHours(1),
+        ]);
+
+        $completed->logs()->create([
+            'index' => 0,
+            'now' => $now->subHours(1),
+            'class' => 'Workbench\App\Activities\ShipReport',
+            'result' => Serializer::serialize(['status' => 'complete']),
+            'created_at' => $now->subHours(1),
+        ]);
+
+        $continuedParent = StoredWorkflow::create([
+            'class' => \Workbench\App\Workflows\TestContinueAsNewWorkflow::class,
+            'arguments' => Serializer::serialize(['page' => 1]),
+            'output' => null,
+            'status' => 'continued',
+            'created_at' => $now->subDay(),
+            'updated_at' => $now->subHours(18),
+        ]);
+
+        $continuedChild = StoredWorkflow::create([
+            'class' => \Workbench\App\Workflows\TestContinueAsNewWorkflow::class,
+            'arguments' => Serializer::serialize(['page' => 2]),
+            'output' => null,
+            'status' => 'running',
+            'created_at' => $now->subHours(12),
+            'updated_at' => $now->subMinutes(5),
+        ]);
+
+        $continuedParent->children()->attach($continuedChild->id, [
+            'parent_index' => StoredWorkflow::CONTINUE_PARENT_INDEX,
+            'parent_now' => $now->subHours(12),
+        ]);
+
+        $failed = StoredWorkflow::create([
+            'class' => \Workbench\App\Workflows\TestWorkflow::class,
+            'arguments' => Serializer::serialize(['attempt' => 3]),
+            'output' => null,
+            'status' => 'failed',
+            'created_at' => $now->subHours(6),
+            'updated_at' => $now->subHours(5),
+        ]);
+
+        $failed->logs()->create([
+            'index' => 0,
+            'now' => $now->subHours(5),
+            'class' => 'Workbench\App\Activities\PersistResult',
+            'result' => Serializer::serialize(['status' => 'failed']),
+            'created_at' => $now->subHours(5),
+        ]);
+
+        $failed->exceptions()->create([
+            'class' => 'Workbench\App\Activities\PersistResult',
+            'exception' => Serializer::serialize(new Exception('Synthetic dashboard fixture failure')),
+            'created_at' => $now->subHours(5),
+        ]);
+
+        $this->info('Seeded dashboard fixtures.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/workbench/app/Console/SeedDashboardFixtures.php
+++ b/workbench/app/Console/SeedDashboardFixtures.php
@@ -4,7 +4,7 @@ namespace Workbench\App\Console;
 
 use Exception;
 use Illuminate\Console\Command;
-use Illuminate\Support\CarbonImmutable;
+use Illuminate\Support\Carbon;
 use Workflow\Models\StoredWorkflow;
 use Workflow\Serializers\Serializer;
 
@@ -37,7 +37,7 @@ class SeedDashboardFixtures extends Command
             return Command::SUCCESS;
         }
 
-        $now = CarbonImmutable::now();
+        $now = Carbon::now();
 
         $running = StoredWorkflow::create([
             'class' => \Workbench\App\Workflows\TestWorkflow::class,

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -18,6 +18,7 @@ class WorkbenchServiceProvider extends ServiceProvider
                 \Workbench\App\Console\CreateTestWorkflow::class,
                 \Workbench\App\Console\CreateTestParentWorkflow::class,
                 \Workbench\App\Console\CreateTestContinueAsNewWorkflow::class,
+                \Workbench\App\Console\SeedDashboardFixtures::class,
             ]);
         }
     }


### PR DESCRIPTION
## Summary
- keep the full devcontainer stack running for Copilot instead of using the setup workflow as a pre-agent CI job
- publish Waterline assets, migrate the workbench sqlite database, start a queue worker, and seed demo workflows
- stop tearing the environment down before the Copilot agent starts

## Testing
- workflow YAML reviewed locally
- GitHub Actions run will validate the setup sequence
