### PR TITLE
Rename package to durable-workflow/waterline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,10 @@
 {
-    "name": "laravel-workflow/waterline",
+    "name": "durable-workflow/waterline",
     "description": "An elegant UI for monitoring Laravel Workflows.",
     "license": "MIT",
+    "replace": {
+        "laravel-workflow/waterline": "self.version"
+    },
     "authors": [
         {
             "name": "Richard McDaniel",
@@ -11,7 +14,7 @@
     "require": {
         "php": "^8.0.2",
         "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0",
-        "laravel-workflow/laravel-workflow": "^1.0"
+        "durable-workflow/workflow": "^1.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",


### PR DESCRIPTION
## Summary
- Rename the Composer package from \`laravel-workflow/waterline\` to \`durable-workflow/waterline\`.
- Update workflow dependency from \`laravel-workflow/laravel-workflow\` to \`durable-workflow/workflow\` (still \`^1.0\` on the v1 line).
- Add a \`replace\` clause so the old name keeps resolving for existing consumers.
- PHP namespace (\`Waterline\\\`) is unchanged.

## Follow-ups (out of scope)
- README / docs updates
- Packagist: submit new package, mark old one abandoned
- \`composer.lock\` regeneration (blocked on new workflow package being published)

## Test plan
- [ ] \`composer validate\` passes
- [ ] After workflow rename lands + publishes, \`composer install\` resolves cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)