### PR TITLE
Rename to durable-workflow/waterline, allow workflow v1 or v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,10 @@
 {
-    "name": "laravel-workflow/waterline",
+    "name": "durable-workflow/waterline",
     "description": "An elegant UI for monitoring Laravel Workflows.",
     "license": "MIT",
+    "replace": {
+        "laravel-workflow/waterline": "self.version"
+    },
     "authors": [
         {
             "name": "Richard McDaniel",
@@ -11,7 +14,7 @@
     "require": {
         "php": "^8.0.2",
         "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0",
-        "laravel-workflow/laravel-workflow": "^1.0"
+        "durable-workflow/workflow": "^1.0 || ^2.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",


### PR DESCRIPTION
## Summary
- Rename the Composer package from \`laravel-workflow/waterline\` to \`durable-workflow/waterline\` on the v2 branch.
- Broaden workflow dependency from \`^1.0\` to \`^1.0 || ^2.0\`, unblocking the v1→v2 workflow upgrade (fixes [zorporation/durable-workflow#149](https://github.com/zorporation/durable-workflow/issues/149)).
- Add \`replace\` clause for backward compatibility.
- PHP namespace (\`Waterline\\\`) unchanged.

Companion to #51 (same rename on master).

## Follow-ups (out of scope)
- README / docs updates
- Packagist submit/abandon
- Lockfile regeneration (post-publish)

## Test plan
- [ ] \`composer validate\` passes
- [ ] After dependencies publish, install works against both workflow v1 and v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)